### PR TITLE
lib: Update regex in `author_name`

### DIFF
--- a/xpm/lib/util.lua
+++ b/xpm/lib/util.lua
@@ -83,7 +83,7 @@ function M.sanitize_plugin_name(name)
 end
 
 function M.author_name(name)
-  name = string.match(name, "([A-Za-z0-9%-]+)/")
+  name = string.match(name, "([A-Za-z0-9%-:]+)/")
   return name
 end
 


### PR DESCRIPTION
to match the shorthand URL notation `host:user`, allowing xpm to recognize previously checked-out plugins from e.g. gitlab.

This doesn't exactly address #8, but it's currently blocking me from installing/using plugins from Gitlab directly.